### PR TITLE
Feature/#1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17
+
+COPY build/libs/*T.jar app.jar
+ENTRYPOINT ["java", "-jar","-Dspring.profiles.active=prod","app.jar"]

--- a/src/main/java/com/playdata/config/ApplicationConfig.java
+++ b/src/main/java/com/playdata/config/ApplicationConfig.java
@@ -1,0 +1,33 @@
+package com.playdata.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@RequiredArgsConstructor
+public class ApplicationConfig {
+    private final JwtService jwtService;
+
+    private int strength = 10;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(strength);
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authenticationProvider
+                = new DaoAuthenticationProvider();
+
+        authenticationProvider.setPasswordEncoder(passwordEncoder());
+        authenticationProvider.setUserDetailsService(jwtService::parseToken);
+
+        return authenticationProvider;
+    }
+}

--- a/src/main/java/com/playdata/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/playdata/config/JwtAuthenticationFilter.java
@@ -1,0 +1,48 @@
+package com.playdata.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+
+
+    @Override
+    protected void doFilterInternal
+            (HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization");
+
+        if(authHeader == null || !authHeader.startsWith("Bearer ")){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.replace("Bearer ", "");
+        TokenInfo tokenInfo = jwtService.parseToken(token);
+
+        if(tokenInfo != null
+                && !tokenInfo.getId().toString().isEmpty()
+                && SecurityContextHolder.getContext().getAuthentication() == null){
+            UsernamePasswordAuthenticationToken authToken
+                    = new UsernamePasswordAuthenticationToken(tokenInfo, null,tokenInfo.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
+        filterChain.doFilter(request, response);
+
+    }
+}

--- a/src/main/java/com/playdata/config/SecurityConfig.java
+++ b/src/main/java/com/playdata/config/SecurityConfig.java
@@ -1,0 +1,41 @@
+package com.playdata.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final AuthenticationProvider authenticationProvider;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity security) throws Exception {
+        security.csrf(AbstractHttpConfigurer::disable);
+        security.sessionManagement(
+                configurer -> configurer.sessionCreationPolicy(
+                        SessionCreationPolicy.STATELESS
+                ));
+        security.authenticationProvider(authenticationProvider);
+        security.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        security.authorizeHttpRequests(req ->
+                req.anyRequest().authenticated()
+        );
+
+        return security.build();
+
+
+    }
+}

--- a/src/main/java/com/playdata/domain/mentoring/entity/Mentoring.java
+++ b/src/main/java/com/playdata/domain/mentoring/entity/Mentoring.java
@@ -1,0 +1,38 @@
+package com.playdata.domain.mentoring.entity;
+
+import com.playdata.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "mentoring")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+public class Mentoring {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Member mentor;
+
+    @ManyToOne
+    private Member mentee;
+
+    @Enumerated(EnumType.STRING)
+    private MentoringStatus status;
+
+    @Builder
+    public Mentoring(Member mentee, Member mentor, MentoringStatus status) {
+        this.mentee = mentee;
+        this.mentor = mentor;
+        this.status = status;
+    }
+
+    public void setStatus(MentoringStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/playdata/domain/mentoring/entity/MentoringStatus.java
+++ b/src/main/java/com/playdata/domain/mentoring/entity/MentoringStatus.java
@@ -1,0 +1,5 @@
+package com.playdata.domain.mentoring.entity;
+
+public enum MentoringStatus {
+    PENDING, ACCEPTED, REJECTED
+}

--- a/src/main/java/com/playdata/domain/mentoring/repository/MentoringRepository.java
+++ b/src/main/java/com/playdata/domain/mentoring/repository/MentoringRepository.java
@@ -1,0 +1,11 @@
+package com.playdata.domain.mentoring.repository;
+
+import com.playdata.domain.mentoring.entity.Mentoring;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface MentoringRepository extends JpaRepository<Mentoring, UUID> {
+    Mentoring findById(UUID mentorId, UUID menteeId);
+}

--- a/src/main/java/com/playdata/domain/mentoring/response/MentoringRequest.java
+++ b/src/main/java/com/playdata/domain/mentoring/response/MentoringRequest.java
@@ -1,0 +1,10 @@
+package com.playdata.domain.mentoring.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MentoringRequest {
+    private String toMemberId;
+}

--- a/src/main/java/com/playdata/exception/MemberNotFoundException.java
+++ b/src/main/java/com/playdata/exception/MemberNotFoundException.java
@@ -1,0 +1,8 @@
+package com.playdata.exception;
+
+public class MemberNotFoundException extends RuntimeException{
+    public MemberNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/playdata/mentoring/controller/MentoringController.java
+++ b/src/main/java/com/playdata/mentoring/controller/MentoringController.java
@@ -1,0 +1,43 @@
+package com.playdata.mentoring.controller;
+
+import com.playdata.config.TokenInfo;
+import com.playdata.domain.mentoring.response.MentoringRequest;
+import com.playdata.mentoring.service.MentoringService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mentoring")
+public class MentoringController {
+
+    private final MentoringService mentoringService;
+
+
+    // 멘토링 요청 보내기
+    @PostMapping("/request")
+    public void sendMentoringRequest(
+            @AuthenticationPrincipal TokenInfo tokenInfo,
+            @RequestBody MentoringRequest request) {
+
+        mentoringService.sendRequest(tokenInfo.getId(), UUID.fromString(request.getToMemberId()));
+    }
+
+    // 멘토링 요청 수락
+    @PostMapping("/accept")
+    public void acceptMentoringRequest(@RequestBody UUID mentorId, UUID menteeId) {
+        mentoringService.acceptRequest(mentorId, menteeId);
+    }
+
+    // 멘토링 요청 거절
+    @PostMapping("/reject")
+    public void rejectMentoringRequest(@RequestBody UUID mentorId, UUID menteeId) {
+        mentoringService.rejectRequest(mentorId, menteeId);
+    }
+}

--- a/src/main/java/com/playdata/mentoring/service/MentoringService.java
+++ b/src/main/java/com/playdata/mentoring/service/MentoringService.java
@@ -1,0 +1,56 @@
+package com.playdata.mentoring.service;
+
+import com.playdata.domain.member.entity.Member;
+import com.playdata.domain.member.repository.MemberRepository;
+import com.playdata.domain.mentoring.entity.Mentoring;
+import com.playdata.domain.mentoring.entity.MentoringStatus;
+import com.playdata.domain.mentoring.repository.MentoringRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+
+@Service
+@RequiredArgsConstructor
+public class MentoringService {
+
+    private final MentoringRepository mentoringRepository;
+    private final MemberRepository memberRepository;
+
+    // 예를 들어 front에서 멘토링 신청을 누른 memberId는 fromMemberId가 된다
+    //  멘토링 요청을 받은 memberId는 toMemberId가 된다
+    // 각각의 id를 back에서 전달 받고 요청을 보내고 처음 상태는 PENDING 상태로 저장이 된다
+    public void sendRequest(UUID fromMemberId, UUID toMemberId) {
+
+        Member fromMember = findMemberById(fromMemberId);
+        Member toMember = findMemberById(toMemberId);
+
+        Mentoring mentoring = Mentoring.builder()
+                .mentee(fromMember)
+                .mentor(toMember)
+                .status(MentoringStatus.PENDING)
+                .build();
+        mentoringRepository.save(mentoring);
+    }
+
+    // 멘토링 요청을 수락한다
+    public void acceptRequest(UUID mentorId, UUID menteeId) {
+        Mentoring mentoring = mentoringRepository.findById(mentorId, menteeId);
+        mentoring.setStatus(MentoringStatus.ACCEPTED);
+        mentoringRepository.save(mentoring);
+    }
+
+//    //멘토링 요청을 거절한다
+    public void rejectRequest(UUID mentorId, UUID menteeId) {
+        Mentoring mentoring = mentoringRepository.findById(mentorId, menteeId);
+        mentoring.setStatus(MentoringStatus.REJECTED);
+        mentoringRepository.save(mentoring);
+    }
+
+    private Member findMemberById(UUID memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("Member not found"));
+    }
+}

--- a/src/main/java/com/playdata/mentoring/service/MentoringService.java
+++ b/src/main/java/com/playdata/mentoring/service/MentoringService.java
@@ -5,6 +5,7 @@ import com.playdata.domain.member.repository.MemberRepository;
 import com.playdata.domain.mentoring.entity.Mentoring;
 import com.playdata.domain.mentoring.entity.MentoringStatus;
 import com.playdata.domain.mentoring.repository.MentoringRepository;
+import com.playdata.exception.MemberNotFoundException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -51,6 +52,6 @@ public class MentoringService {
 
     private Member findMemberById(UUID memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException("Member not found"));
+                .orElseThrow(() -> new MemberNotFoundException("Member not found"));
     }
 }


### PR DESCRIPTION
로그인한 유저의 token info에서 받아온 memberId를 멘티로 설정하였고 멘토링 요청을 받은 memberId를 멘토로 설정했습니다
enum으로 PENDING, ACCEPTED, REJECTED 나눠서
초기에는 PENDING
받아들이면 ACCEPTED
거절하면 REJECTED
추후에 REJECTED 상태는 다시 멘토링 요청을 못하게 그리고 REJECTED 상태의 목록을 멘토가 정리할 수 있는 기능을 추가하여 고도화 할 예정입니다